### PR TITLE
C version: Make Sec-WebSocket-Protocol optional.

### DIFF
--- a/c/websocket.h
+++ b/c/websocket.h
@@ -15,7 +15,7 @@ Connection: Upgrade\r\n\
 Upgrade: websocket\r\n\
 Connection: Upgrade\r\n\
 Sec-WebSocket-Accept: %s\r\n\
-Sec-WebSocket-Protocol: %s\r\n\
+%s%s%s\
 \r\n"
 
 #define HYBI_GUID "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"


### PR DESCRIPTION
My browser doesn't sent the Sec-WebSocket-Protocol, which made the C version of websockfy not accept the connection.  Making it optional doesn't seem to have any adverse effect.