### PR TITLE
Make it work in 2023

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,7 +1,10 @@
-TARGETS=websockify
+TARGETS=websockify echoserver
 CFLAGS += -fPIC
 
 all: $(TARGETS)
+
+echoserver: echo.c
+	$(CC) $(LDFLAGS) $^ -lssl -lcrypto -o $@
 
 websockify: websockify.o websocket.o
 	$(CC) $(LDFLAGS) $^ -lssl -lcrypto -o $@
@@ -10,5 +13,5 @@ websocket.o: websocket.c websocket.h
 websockify.o: websockify.c websocket.h
 
 clean:
-	rm -f websockify *.o
+	rm -f websockify *.o echoserver
 

--- a/c/README.txt
+++ b/c/README.txt
@@ -1,0 +1,28 @@
+
+This is the proof of concept websocket server.  It runs
+on the unmodified live server and bridges websockets.
+
+the basic configuration is to run 
+
+	websockify hostname:listensocket hostname:targetsocket
+
+listensocket is a random available socket (open it in the firewall)
+targetsocket is the customary server port for the test server. 
+
+for testing purposes, you can use echoserver as the target, or netcat
+
+in principle, whatever service you normally provide on targetsocket
+can run unchanged. 
+
+
+echo.c is a simple echo server cribbed from a random internet page.
+
+
+so summary: the server runs unmodified
+	    websockify runs as a proxy between 
+
+webchat.html is a simple test that connects to websockify and pings
+a few lines, expecting them to be echoed.  to run this test, set up
+websockify to listen on port 12346 and connect to echoserver on any
+port you wish.
+

--- a/c/echo.c
+++ b/c/echo.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
+#define BUFFER_SIZE 1024
+#define on_error(...) { fprintf(stderr, __VA_ARGS__); fflush(stderr); exit(1); }
+
+int main (int argc, char *argv[]) {
+  if (argc < 2) on_error("Usage: %s [port]\n", argv[0]);
+
+  int port = atoi(argv[1]);
+
+  int server_fd, client_fd, err;
+  struct sockaddr_in server, client;
+  char buf[BUFFER_SIZE];
+
+  server_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (server_fd < 0) on_error("Could not create socket\n");
+
+  server.sin_family = AF_INET;
+  server.sin_port = htons(port);
+  server.sin_addr.s_addr = htonl(INADDR_ANY);
+
+  int opt_val = 1;
+  setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt_val, sizeof opt_val);
+
+  err = bind(server_fd, (struct sockaddr *) &server, sizeof(server));
+  if (err < 0) on_error("Could not bind socket\n");
+
+  err = listen(server_fd, 128);
+  if (err < 0) on_error("Could not listen on socket\n");
+
+  printf("Server is listening on %d\n", port);
+
+  while (1) {
+    socklen_t client_len = sizeof(client);
+    client_fd = accept(server_fd, (struct sockaddr *) &client, &client_len);
+
+    if (client_fd < 0) on_error("Could not establish new connection\n");
+    printf("listening\n");
+    while (1) {
+      int read = recv(client_fd, buf, BUFFER_SIZE, 0);
+      
+      if (!read) 
+	{ printf("done reading\n"); break; // done reading
+        }
+      if (read < 0) on_error("Client read failed\n");
+      buf[read] = (char)0;
+      printf("in: %s",buf);
+
+      err = send(client_fd, buf, read, 0);
+      if (err < 0) on_error("Client write failed\n");
+    }
+  }
+
+  return 0;
+}

--- a/c/startserver
+++ b/c/startserver
@@ -1,0 +1,5 @@
+#!/bin/sh
+#
+# this script has to be executed as root to get access to the key files
+#
+./websockify -k /etc/letsencrypt/live/boardspace.net/privkey.pem -c /etc/letsencrypt/live/boardspace.net/cert.pem  boardspace.net:12345 boardspace.net:2255

--- a/c/webchat.html
+++ b/c/webchat.html
@@ -1,0 +1,79 @@
+ 
+  <head>
+    <title>WebSocket client test</title>
+  </head>
+
+  <body>
+    <h1>WebSocket Client Test</h1>
+    <div id="log"></div>
+  </body>
+
+<script language="javascript" type="text/javascript">
+
+    var wsUri = "wss://boardspace.net:12346/chat"; //"ws:/localhost:8887";
+    var log;
+     //websocket.close();
+      //websocket.close();
+
+    const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
+  
+    function init()
+    {
+      log = document.getElementById("log");
+      testWebSocket();
+      
+    }
+
+    function testWebSocket()
+    {
+      websocket = new WebSocket(wsUri);
+      websocket.onopen    = function(evt) { onOpen(evt)    };
+      websocket.onclose   = function(evt) { onClose(evt)   };
+      websocket.onmessage = function(evt) { onMessage(evt) };
+      websocket.onerror   = function(evt) { onError(evt)   };
+    }
+
+    async function onOpen(evt)
+    {
+      writeLog("CONNECTED");
+      sendMessage("Hello world\n");
+      await sleep(5000);
+      sendMessage("test line 1\n");
+      await sleep(5000)
+      sendMessage("test line 2\n");
+      await sleep(5000);
+      websocket.close();
+    }
+
+    function onClose(evt)
+    {
+      writeLog("Websocket DISCONNECTED");
+    }
+
+    function onMessage(evt)
+    {
+      writeLog('<span style="color: blue;">RESPONSE: ' + evt.data+'</span>');
+    }
+
+    function onError(evt)
+    {
+      writeLog('<span style="color: red;">ERROR:</span> ' + evt.data);
+    }
+
+    function sendMessage(message)
+    {
+      writeLog("SENT: " + message);
+      websocket.send(message);
+    }
+
+    function writeLog(message)
+    {
+      var pre = document.createElement("p");
+      pre.innerHTML = message;
+      log.appendChild(pre);
+    }
+
+    window.addEventListener("load", init, false);
+
+  </script>
+  

--- a/c/websocket.h
+++ b/c/websocket.h
@@ -57,6 +57,7 @@ typedef struct {
 
 typedef struct {
     int verbose;
+    int veryverbose;
     char listen_host[256];
     int listen_port;
     void (*handler)(ws_ctx_t*);


### PR DESCRIPTION
Remove some "base64" encoding which seems to be deprecated Add a more verbose option as -V
Fix linkage to SSL to work with older versions of openssl add internal documentation to *.c
add some other samples and useful hints